### PR TITLE
feat: Add region handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
-    "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
+    "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true, "destructuredArrayIgnorePattern": "^_" }],
     "@typescript-eslint/no-empty-function": ["error", { "allow": ["arrowFunctions"] }],
     "eol-last": ["error", "always"],
     "semi": ["error", "always"],

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,7 @@ Enter your roles in the editor via `ini` format:
 | `aws_account_id` | The aws account id where the role is stored |
 | `color` (optional) | A css color string, like `#f0f0f0` or `orange` |
 | `group` (optional) | The name of a group |
+| `region` (optional) | Force a region ([region list](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)) |
 
 ### Example config
 
@@ -24,6 +25,13 @@ role_name = AdminFullAccess
 aws_account_id = 123456789101
 color = orangered
 group = My awesome account
+
+[role-title-eu-central]
+role_name = AdminFullAccess
+aws_account_id = 123456789101
+color = blue
+group = My awesome account
+region = eu-central-1
 ```
 
 ## Usage

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,6 +11,7 @@ Enter your roles in the editor via `ini` format:
 | :---  |  :---  |
 | `role_name` | The role's name you want to assume |
 | `aws_account_id` | The aws account id where the role is stored |
+| `role_arn` (optional) | An aws role arn including account id and role name (replaces `role_name` & `aws_account_id`) |
 | `color` (optional) | A css color string, like `#f0f0f0` or `orange` |
 | `group` (optional) | The name of a group |
 | `region` (optional) | Force a region ([region list](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)) |
@@ -27,9 +28,7 @@ color = orangered
 group = My awesome account
 
 [role-title-eu-central]
-role_name = AdminFullAccess
-aws_account_id = 123456789101
-color = blue
+role_arn = arn:aws:iam::123456789101:role/AdminFullAccess
 group = My awesome account
 region = eu-central-1
 ```
@@ -38,7 +37,7 @@ region = eu-central-1
 
 After entering your config, roles will show up in the popup window. You can filter roles via the search input. 
 
-?> Assuming a role after selection will only work when you are on an aws console tab. 
+Assuming a role after selection will only work when you are on an aws console tab. 
 
 
 ### Keyboard Shortcuts

--- a/src/background/handlers/redirectListener.spec.ts
+++ b/src/background/handlers/redirectListener.spec.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
 });
 
 it('should call updateUrl with params', () => {
-  mock(mapToSwitchForm).mockReturnValue({ foo: 'bar' } as unknown as SwitchRoleForm);
+  mock(mapToSwitchForm).mockReturnValue({ foo: 'bar', bar: undefined } as unknown as SwitchRoleForm);
   redirectListener(
     { type: 'redirect' } as Message, 
     { tab: { id: 1337 } } as chrome.runtime.MessageSender,

--- a/src/background/handlers/redirectListener.ts
+++ b/src/background/handlers/redirectListener.ts
@@ -1,6 +1,9 @@
 import { updateTabUrl } from '../../common/browser/tabs';
 import { mapToSwitchForm } from '../../common/mappers';
 
+const removeUndefinedEntries = (obj: object) => Object.fromEntries(
+  Object.entries(obj).filter(([_, v]) => v));
+
 export const redirectListener = async (
   { type, ...configItem }: Message, 
   sender: chrome.runtime.MessageSender,
@@ -10,7 +13,7 @@ export const redirectListener = async (
       redirect_uri: sender.url || 'https://console.aws.amazon.com/console',
       _fromAWSRoleSwitchExtension: 'true',
     });
-    const urlParams = new URLSearchParams(params).toString();
+    const urlParams = new URLSearchParams(removeUndefinedEntries(params)).toString();
     await updateTabUrl(`https://signin.aws.amazon.com/switchrole?${urlParams}`);
   }
 };

--- a/src/common/config/availableRegions.ts
+++ b/src/common/config/availableRegions.ts
@@ -1,0 +1,32 @@
+export const AWS_REGIONS = [
+  "us-east-2",
+  "us-east-1",
+  "us-west-1",
+  "us-west-2",
+  "af-south-1",
+  "ap-east-1",
+  "ap-southeast-3",
+  "ap-south-1",
+  "ap-northeast-3",
+  "ap-northeast-2",
+  "ap-southeast-1",
+  "ap-southeast-2",
+  "ap-northeast-1",
+  "ca-central-1",
+  "eu-central-1",
+  "eu-west-1",
+  "eu-west-2",
+  "eu-south-1",
+  "eu-west-3",
+  "eu-north-1",
+  "eu-central-2",
+  "me-south-1",
+  "me-central-1",
+  "sa-east-1",
+  "us-gov-east-1",
+  "us-gov-west-1"
+] as const;
+
+export const availableRegions = AWS_REGIONS as ReadonlyArray<string>;
+
+export type AWSRegion = typeof AWS_REGIONS;

--- a/src/common/config/mapper.spec.ts
+++ b/src/common/config/mapper.spec.ts
@@ -24,6 +24,7 @@ Array [
   Object {
     "aws_account_id": "123456789012",
     "color": undefined,
+    "region": undefined,
     "role_name": "MyRole",
     "title": "baz",
   },
@@ -37,6 +38,7 @@ Array [
   Object {
     "aws_account_id": "foo",
     "color": undefined,
+    "region": undefined,
     "role_name": "bar",
     "title": "foo",
   },
@@ -62,6 +64,7 @@ Array [
   Object {
     "aws_account_id": "foo",
     "color": undefined,
+    "region": undefined,
     "role_name": "bar",
     "title": "foo",
   },
@@ -69,6 +72,7 @@ Array [
     "aws_account_id": "foo",
     "color": undefined,
     "group": "baz",
+    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },
@@ -99,6 +103,7 @@ Array [
   Object {
     "aws_account_id": "foo",
     "color": undefined,
+    "region": undefined,
     "role_name": "ccc",
     "title": "foo",
   },
@@ -106,6 +111,7 @@ Array [
     "aws_account_id": "foo",
     "color": undefined,
     "group": "aaa",
+    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },
@@ -113,6 +119,7 @@ Array [
     "aws_account_id": "foo",
     "color": undefined,
     "group": "bbb",
+    "region": undefined,
     "role_name": "bar",
     "title": "baz",
   },
@@ -137,6 +144,7 @@ Array [
   Object {
     "aws_account_id": "foo",
     "color": undefined,
+    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },
@@ -144,6 +152,49 @@ Array [
 `);
 });
 
+it('should map region', () => {
+  const stored = {
+    'foo': {
+      aws_account_id: 'foo',
+      role_name: 'bar',
+      region: 'eu-central-1'
+    },
+  };
+  const config = mapConfig(stored as object as StoredConfig);
+  expect(config).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "aws_account_id": "foo",
+    "color": undefined,
+    "region": "eu-central-1",
+    "role_name": "bar",
+    "title": "foo",
+  },
+]
+`);
+});
+
+it('should not map invalid region', () => {
+  const stored = {
+    'foo': {
+      aws_account_id: 'foo',
+      role_name: 'bar',
+      region: 'us-dummy-1'
+    },
+  };
+  const config = mapConfig(stored as object as StoredConfig);
+  expect(config).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "aws_account_id": "foo",
+    "color": undefined,
+    "region": undefined,
+    "role_name": "bar",
+    "title": "foo",
+  },
+]
+`);
+});
 
 it('should sort correctly', () => {
   const stored = {
@@ -175,6 +226,7 @@ Array [
     "aws_account_id": "foo",
     "color": undefined,
     "group": undefined,
+    "region": undefined,
     "role_name": "bar",
     "title": "bar2",
   },
@@ -182,6 +234,7 @@ Array [
     "aws_account_id": "foo",
     "color": undefined,
     "group": "b",
+    "region": undefined,
     "role_name": "bar",
     "title": "foo",
   },
@@ -189,6 +242,7 @@ Array [
     "aws_account_id": "foo",
     "color": undefined,
     "group": "b",
+    "region": undefined,
     "role_name": "bar",
     "title": "foo2",
   },
@@ -196,6 +250,7 @@ Array [
     "aws_account_id": "foo",
     "color": undefined,
     "group": "a",
+    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },

--- a/src/common/config/mapper.spec.ts
+++ b/src/common/config/mapper.spec.ts
@@ -11,7 +11,8 @@ it('should map to default group', () => {
     },
     'profile bar': {
       aws_account_id: 'foo',
-      role_name: 'bar'
+      role_name: 'bar',
+      region: 'us-east-1'
     },
     'baz': {
       role_arn: 'arn:aws:iam::123456789012:role/MyRole'
@@ -29,6 +30,7 @@ Array [
   Object {
     "aws_account_id": "foo",
     "color": undefined,
+    "region": "us-east-1",
     "role_name": "bar",
     "title": "bar",
   },

--- a/src/common/config/mapper.ts
+++ b/src/common/config/mapper.ts
@@ -1,5 +1,7 @@
 import { ColorTranslator } from 'colortranslator';
 
+import { availableRegions } from './availableRegions';
+
 type AccountRole = { role_name: string, aws_account_id: string }
 
 const isValidEntry = ({aws_account_id, role_name, role_arn}: AWSStoredConfigItem): boolean =>
@@ -13,16 +15,9 @@ function getColorHEX(color: string) {
   }
 }
 
-function mapColor({ color = '', ...rest }: AWSConfigItem): AWSConfigItem {
-  return {
-    ...rest,
-    color: getColorHEX(color)
-  };
-}
+const mapColor = ({ color = '', ...rest }: AWSConfigItem): AWSConfigItem => ({ ...rest, color: getColorHEX(color) });
 
-function trimTitle(title: string) {
-  return title.replace('profile', '').trim();
-}
+const trimTitle = (title: string) => title.replace('profile', '').trim();
 
 // sorts the config by first appearance of a group
 // ungrouped entries should still be on top
@@ -58,13 +53,14 @@ const sortByGroupIndex = (config: AWSConfig) => {
 
 export const awsStoredConfigItemToAWSConfigItem = (
   title: string, 
-  sci: AWSStoredConfigItem
+  { aws_account_id, role_arn, role_name, region: regionTo, ...rest }: AWSStoredConfigItem
 ): AWSConfigItem | undefined => {
-  const { aws_account_id, role_arn, role_name, ...rest } = sci;
+  const region = availableRegions.includes(regionTo || '') && regionTo || undefined;
 
   if (aws_account_id && role_name) {
     return {
       ...rest,
+      region,
       title,
       aws_account_id,
       role_name,
@@ -76,6 +72,7 @@ export const awsStoredConfigItemToAWSConfigItem = (
     if (accountAndRole) {
       const item: AWSConfigItem = {
         title,
+        region,
         ...rest,
         ...accountAndRole,
       };

--- a/src/common/mappers/switchForm.spec.ts
+++ b/src/common/mappers/switchForm.spec.ts
@@ -1,0 +1,90 @@
+import { mapToSwitchForm } from "./switchForm";
+
+it('map region to redirect url', () => {
+  const params = mapToSwitchForm({
+    aws_account_id: 'dummy',
+    role_name: 'DummyAdmin',
+    title: 'dummy-account',
+    region: 'eu-central-1',
+  }, {
+    redirect_uri: 'https://example.com?region=us-east-2'
+  });
+
+  expect(params).toMatchInlineSnapshot(`
+Object {
+  "account": "dummy",
+  "action": "switchFromBasis",
+  "color": undefined,
+  "displayName": "dummy-account | dummy",
+  "mfaNeeded": "0",
+  "redirect_uri": "https://example.com/?region=eu-central-1",
+  "roleName": "DummyAdmin",
+}
+`);
+});
+
+it('keep region in redirect url', () => {
+  const params = mapToSwitchForm({
+    aws_account_id: 'dummy',
+    role_name: 'DummyAdmin',
+    title: 'dummy-account',
+  }, {
+    redirect_uri: 'https://example.com?region=us-east-2'
+  });
+
+  expect(params).toMatchInlineSnapshot(`
+Object {
+  "account": "dummy",
+  "action": "switchFromBasis",
+  "color": undefined,
+  "displayName": "dummy-account | dummy",
+  "mfaNeeded": "0",
+  "redirect_uri": "https://example.com/?region=us-east-2",
+  "roleName": "DummyAdmin",
+}
+`);
+});
+
+it('take default (us-east-1) region in redirect url when not defined', () => {
+  const params = mapToSwitchForm({
+    aws_account_id: 'dummy',
+    role_name: 'DummyAdmin',
+    title: 'dummy-account',
+  }, {
+    redirect_uri: 'https://example.com'
+  });
+
+  expect(params).toMatchInlineSnapshot(`
+Object {
+  "account": "dummy",
+  "action": "switchFromBasis",
+  "color": undefined,
+  "displayName": "dummy-account | dummy",
+  "mfaNeeded": "0",
+  "redirect_uri": "https://example.com/?region=us-east-1",
+  "roleName": "DummyAdmin",
+}
+`);
+});
+
+it('keep invalid redirect url', () => {
+  const params = mapToSwitchForm({
+    aws_account_id: 'dummy',
+    role_name: 'DummyAdmin',
+    title: 'dummy-account',
+  }, {
+    redirect_uri: 'example.com?region=us-east-2'
+  });
+
+  expect(params).toMatchInlineSnapshot(`
+Object {
+  "account": "dummy",
+  "action": "switchFromBasis",
+  "color": undefined,
+  "displayName": "dummy-account | dummy",
+  "mfaNeeded": "0",
+  "redirect_uri": "example.com?region=us-east-2",
+  "roleName": "DummyAdmin",
+}
+`);
+});

--- a/src/common/mappers/switchForm.spec.ts
+++ b/src/common/mappers/switchForm.spec.ts
@@ -88,3 +88,26 @@ Object {
 }
 `);
 });
+
+it('region not written correctly', () => {
+  const params = mapToSwitchForm({
+    aws_account_id: 'dummy',
+    role_name: 'DummyAdmin',
+    title: 'dummy-account',
+    region: 'us-east-foooo',
+  }, {
+    redirect_uri: 'example.com?region=us-east-2'
+  });
+
+  expect(params).toMatchInlineSnapshot(`
+Object {
+  "account": "dummy",
+  "action": "switchFromBasis",
+  "color": undefined,
+  "displayName": "dummy-account | dummy",
+  "mfaNeeded": "0",
+  "redirect_uri": "example.com?region=us-east-2",
+  "roleName": "DummyAdmin",
+}
+`);
+});

--- a/src/common/mappers/switchForm.ts
+++ b/src/common/mappers/switchForm.ts
@@ -1,10 +1,40 @@
 type Args = Pick<SwitchRoleForm, 'csrf' | 'redirect_uri' | '_fromAWSRoleSwitchExtension'>
 
+const availableRegions = [
+  "us-east-2",
+  "us-east-1",
+  "us-west-1",
+  "us-west-2",
+  "af-south-1",
+  "ap-east-1",
+  "ap-southeast-3",
+  "ap-south-1",
+  "ap-northeast-3",
+  "ap-northeast-2",
+  "ap-southeast-1",
+  "ap-southeast-2",
+  "ap-northeast-1",
+  "ca-central-1",
+  "eu-central-1",
+  "eu-west-1",
+  "eu-west-2",
+  "eu-south-1",
+  "eu-west-3",
+  "eu-north-1",
+  "eu-central-2",
+  "me-south-1",
+  "me-central-1",
+  "sa-east-1",
+  "us-gov-east-1",
+  "us-gov-west-1"
+];
+
 const createRedirectUrl = (redirectUrl: string, region?: string) => {
   try {
     const url = new URL(redirectUrl);
     const actualRegion = url.searchParams.get('region') || 'us-east-1';
-    url.searchParams.set('region', region || actualRegion);
+    const regionTo = region && availableRegions.includes(region) ? region : actualRegion;
+    url.searchParams.set('region', regionTo);
     return url.toString();
   } catch(_) {
     return redirectUrl;

--- a/src/common/mappers/switchForm.ts
+++ b/src/common/mappers/switchForm.ts
@@ -1,40 +1,10 @@
 type Args = Pick<SwitchRoleForm, 'csrf' | 'redirect_uri' | '_fromAWSRoleSwitchExtension'>
 
-const availableRegions = [
-  "us-east-2",
-  "us-east-1",
-  "us-west-1",
-  "us-west-2",
-  "af-south-1",
-  "ap-east-1",
-  "ap-southeast-3",
-  "ap-south-1",
-  "ap-northeast-3",
-  "ap-northeast-2",
-  "ap-southeast-1",
-  "ap-southeast-2",
-  "ap-northeast-1",
-  "ca-central-1",
-  "eu-central-1",
-  "eu-west-1",
-  "eu-west-2",
-  "eu-south-1",
-  "eu-west-3",
-  "eu-north-1",
-  "eu-central-2",
-  "me-south-1",
-  "me-central-1",
-  "sa-east-1",
-  "us-gov-east-1",
-  "us-gov-west-1"
-];
-
 const createRedirectUrl = (redirectUrl: string, region?: string) => {
   try {
     const url = new URL(redirectUrl);
     const actualRegion = url.searchParams.get('region') || 'us-east-1';
-    const regionTo = region && availableRegions.includes(region) ? region : actualRegion;
-    url.searchParams.set('region', regionTo);
+    url.searchParams.set('region', region || actualRegion as string);
     return url.toString();
   } catch(_) {
     return redirectUrl;

--- a/src/common/mappers/switchForm.ts
+++ b/src/common/mappers/switchForm.ts
@@ -1,5 +1,16 @@
 type Args = Pick<SwitchRoleForm, 'csrf' | 'redirect_uri' | '_fromAWSRoleSwitchExtension'>
 
+const createRedirectUrl = (redirectUrl: string, region?: string) => {
+  try {
+    const url = new URL(redirectUrl);
+    const actualRegion = url.searchParams.get('region') || 'us-east-1';
+    url.searchParams.set('region', region || actualRegion);
+    return url.toString();
+  } catch(_) {
+    return redirectUrl;
+  }
+};
+
 export const mapToSwitchForm = (
   configItem: AWSConfigItem, 
   args: Args,
@@ -11,4 +22,5 @@ export const mapToSwitchForm = (
   action: 'switchFromBasis',
   mfaNeeded: '0',
   ...args,
+  redirect_uri: createRedirectUrl(args.redirect_uri, configItem.region),
 });

--- a/src/content/util/createSigninForm.spec.ts
+++ b/src/content/util/createSigninForm.spec.ts
@@ -41,7 +41,7 @@ it('should create form correctly', () => {
   />
   <input
     name="redirect_uri"
-    value="http://localhost/"
+    value="http://localhost/?region=us-east-1"
   />
 </form>
 `);
@@ -54,7 +54,7 @@ Object {
   "csrf": "1337",
   "displayName": "dummy-title | dummy-id",
   "mfaNeeded": "0",
-  "redirect_uri": "http://localhost/",
+  "redirect_uri": "http://localhost/?region=us-east-1",
   "roleName": "dummy-role",
 }
 `);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -35,6 +35,7 @@ type SwitchRoleFormFromExtension = { _fromAWSRoleSwitchExtension?: 'true' }
 type SwitchRoleForm = {
   account: string,
   roleName: string,
+  region?: string,
   color?: string,
   displayName?: string,
   


### PR DESCRIPTION
Region support means that when a region key/value is present in config, a region change is forced to specified region when asuming a role. When no region is specified, you will stay in the same region you're coming from. The region must be written correctly and is one of: https://gist.github.com/janstuemmel/24026b564188398bb13fa20c65eb98d7

closes #24
closes #30