### PR TITLE
feat: Add support for `target_role_name`

### DIFF
--- a/docs/example-config.ini
+++ b/docs/example-config.ini
@@ -72,3 +72,12 @@ group = Personal AWS Account
 aws_account_id = 257355895763
 role_name = AdminFullAccess
 group = Personal AWS Account
+
+# Project with org
+[my-org]
+aws_account_id = myorg
+target_role_name = AdminFullAccess
+
+[child-profile]
+aws_account_id = 123456789101
+source_profile = my-org

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,6 +35,21 @@ group = My awesome account
 region = eu-central-1
 ```
 
+### Example config with `target_role_name`
+
+```ini
+[my-org]
+aws_account_id = your_org_alias_or_id
+target_role_name = MyRole
+
+[child-profile]
+aws_account_id = 123456789101
+source_profile = my-org
+# uses target_role_name as role_name from above
+```
+
+When using a `source_profile` as parent and there is no `role_arn` specified in the child profile, the child profile uses `target_role_name` as `role_name`. 
+
 ## Usage
 
 After entering your config, roles will show up in the popup window. You can filter roles via the search input. 

--- a/src/background/handlers/redirectListener.ts
+++ b/src/background/handlers/redirectListener.ts
@@ -1,8 +1,6 @@
 import { updateTabUrl } from '../../common/browser/tabs';
 import { mapToSwitchForm } from '../../common/mappers';
-
-const removeUndefinedEntries = (obj: object) => Object.fromEntries(
-  Object.entries(obj).filter(([_, v]) => v));
+import { removeUndefinedEntries } from '../../common/util';
 
 export const redirectListener = async (
   msg: AWSConfigItem, 

--- a/src/common/config/mapper.spec.ts
+++ b/src/common/config/mapper.spec.ts
@@ -20,22 +20,17 @@ it('should map to default group', () => {
 [
   {
     "aws_account_id": "123456789012",
-    "color": undefined,
-    "region": undefined,
     "role_name": "MyRole",
     "title": "baz",
   },
   {
     "aws_account_id": "foo",
-    "color": undefined,
     "region": "us-east-1",
     "role_name": "bar",
     "title": "bar",
   },
   {
     "aws_account_id": "foo",
-    "color": undefined,
-    "region": undefined,
     "role_name": "bar",
     "title": "foo",
   },
@@ -60,16 +55,12 @@ it('should map to groups', () => {
 [
   {
     "aws_account_id": "foo",
-    "color": undefined,
-    "region": undefined,
     "role_name": "bar",
     "title": "foo",
   },
   {
     "aws_account_id": "foo",
-    "color": undefined,
     "group": "baz",
-    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },
@@ -99,24 +90,18 @@ it('should sort by groups', () => {
 [
   {
     "aws_account_id": "foo",
-    "color": undefined,
-    "region": undefined,
     "role_name": "ccc",
     "title": "foo",
   },
   {
     "aws_account_id": "foo",
-    "color": undefined,
     "group": "aaa",
-    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },
   {
     "aws_account_id": "foo",
-    "color": undefined,
     "group": "bbb",
-    "region": undefined,
     "role_name": "bar",
     "title": "baz",
   },
@@ -124,10 +109,10 @@ it('should sort by groups', () => {
 `);
 });
 
-it('should omit entries with invalid values', () => {
+it('should omit entries with missing account_id', () => {
   const stored = {
     'foo': {
-      aws_account_id: 'foo',
+      role_name: 'bar',
     },
     'bar': {
       aws_account_id: 'foo',
@@ -140,8 +125,6 @@ it('should omit entries with invalid values', () => {
 [
   {
     "aws_account_id": "foo",
-    "color": undefined,
-    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },
@@ -164,8 +147,6 @@ it('should omit entry with invalid role_arn', () => {
 [
   {
     "aws_account_id": "foo",
-    "color": undefined,
-    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },
@@ -184,8 +165,6 @@ it('should extract role_name and aws_account_id from role_arn', () => {
 [
   {
     "aws_account_id": "123456789012",
-    "color": undefined,
-    "region": undefined,
     "role_name": "MyRole",
     "title": "foo",
   },
@@ -206,7 +185,6 @@ it('should map region', () => {
 [
   {
     "aws_account_id": "foo",
-    "color": undefined,
     "region": "eu-central-1",
     "role_name": "bar",
     "title": "foo",
@@ -228,8 +206,6 @@ it('should not map invalid region', () => {
 [
   {
     "aws_account_id": "foo",
-    "color": undefined,
-    "region": undefined,
     "role_name": "bar",
     "title": "foo",
   },
@@ -265,33 +241,24 @@ it('should sort correctly', () => {
 [
   {
     "aws_account_id": "foo",
-    "color": undefined,
-    "group": undefined,
-    "region": undefined,
     "role_name": "bar",
     "title": "bar2",
   },
   {
     "aws_account_id": "foo",
-    "color": undefined,
     "group": "b",
-    "region": undefined,
     "role_name": "bar",
     "title": "foo",
   },
   {
     "aws_account_id": "foo",
-    "color": undefined,
     "group": "b",
-    "region": undefined,
     "role_name": "bar",
     "title": "foo2",
   },
   {
     "aws_account_id": "foo",
-    "color": undefined,
     "group": "a",
-    "region": undefined,
     "role_name": "bar",
     "title": "bar",
   },

--- a/src/common/config/mapper.spec.ts
+++ b/src/common/config/mapper.spec.ts
@@ -38,6 +38,30 @@ it('should map to default group', () => {
 `);
 });
 
+it('should map to default group', () => {
+  const stored = {
+    'source': {
+      aws_account_id: 'org',
+      target_role_name: 'UserRole'
+    },
+    'foo': {
+      aws_account_id: 'foo',
+      source_profile: 'source',
+    },
+  } as StoredConfig;
+  const config = mapConfig(stored);
+  expect(config).toMatchInlineSnapshot(`
+[
+  {
+    "aws_account_id": "foo",
+    "role_name": "UserRole",
+    "source_profile": "source",
+    "title": "foo",
+  },
+]
+`);
+});
+
 it('should map to groups', () => {
   const stored = {
     'foo': {
@@ -113,6 +137,29 @@ it('should omit entries with missing account_id', () => {
   const stored = {
     'foo': {
       role_name: 'bar',
+    },
+    'bar': {
+      aws_account_id: 'foo',
+      role_name: 'bar',
+    },
+    'baz': 1337,
+  };
+  const config = mapConfig(stored as object as StoredConfig);
+  expect(config).toMatchInlineSnapshot(`
+[
+  {
+    "aws_account_id": "foo",
+    "role_name": "bar",
+    "title": "bar",
+  },
+]
+`);
+});
+
+it('should omit entries with missing role_name', () => {
+  const stored = {
+    'foo': {
+      aws_account_id: 'bar',
     },
     'bar': {
       aws_account_id: 'foo',

--- a/src/common/config/mapper.spec.ts
+++ b/src/common/config/mapper.spec.ts
@@ -11,7 +11,7 @@ it('should map to default group', () => {
       role_name: 'bar',
       region: 'us-east-1'
     },
-    'baz': {
+    'baz profile': {
       role_arn: 'arn:aws:iam::123456789012:role/MyRole'
     }
   } as StoredConfig;
@@ -21,7 +21,7 @@ it('should map to default group', () => {
   {
     "aws_account_id": "123456789012",
     "role_name": "MyRole",
-    "title": "baz",
+    "title": "baz profile",
   },
   {
     "aws_account_id": "foo",

--- a/src/common/config/mapper.ts
+++ b/src/common/config/mapper.ts
@@ -21,7 +21,7 @@ function getColorHEX(color: string) {
   }
 }
 
-const trimTitle = (title: string) => title.replace('profile', '').trim();
+const trimTitle = (title: string) => title.replace(/^profile/, '').trim();
 
 // sorts the config by first appearance of a group
 // ungrouped entries should still be on top

--- a/src/common/config/mapper.ts
+++ b/src/common/config/mapper.ts
@@ -1,18 +1,17 @@
 import { ColorTranslator } from 'colortranslator';
 
 import { availableRegions } from './availableRegions';
+import { removeUndefinedEntries } from '../util';
 
 // Possible role_name syntax: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
 const ROLE_ARN_REGEX = /^arn:aws:iam::(?<aws_account_id>\d{12}):role\/(?<role_name>[\w+=,.@-]+)/;
+const HEX_COLOR_REGEX = /^(?<hex>[0-9A-Fa-f]{3,8})$/;
 
-const isValidConfigEntry = ({ aws_account_id, role_name, role_arn }: AWSStoredConfigItem): boolean =>
- !!aws_account_id && !!role_name || !!role_arn;
-
-const isValidConfigItem = ({ aws_account_id, role_name }: Partial<AWSConfigItem>): boolean =>
- !!aws_account_id && !!role_name;
+const isValidConfigItem = ({ aws_account_id }: Partial<AWSConfigItem>): boolean =>
+ !!aws_account_id;
 
 function getColorHEX(color: string) {
-  const match = new RegExp(/^(?<hex>[0-9A-Fa-f]{3,8})$/).exec(color);
+  const match = new RegExp(HEX_COLOR_REGEX).exec(color);
   const cssColor = match?.groups?.hex ? `#${match.groups.hex}` : color;
 
   try {
@@ -21,9 +20,6 @@ function getColorHEX(color: string) {
     return undefined;
   }
 }
-
-const mapColor = ({ color = '', ...rest }: Partial<AWSConfigItem>): Partial<AWSConfigItem> => 
-  ({ ...rest, color: getColorHEX(color) });
 
 const trimTitle = (title: string) => title.replace('profile', '').trim();
 
@@ -59,28 +55,25 @@ export const sortByGroupIndex = (config: AWSConfig) => {
   };
 };
 
-const buildConfigItem = (
-  title: string, 
-  { role_arn = '', aws_account_id, role_name, region: regionTo, ...rest }: AWSStoredConfigItem
-): Partial<AWSConfigItem> => {  
+const buildConfigItem = (config: StoredConfig) => (key: string): Partial<AWSConfigItem> => {
+  const { role_arn = '', aws_account_id, role_name, region: regionTo, color = '', ...rest } = config[key];  
   const region = availableRegions.includes(regionTo || '') ? regionTo : undefined;
   const match = new RegExp(ROLE_ARN_REGEX).exec(role_arn);
 
-  return {
+  return removeUndefinedEntries({
     ...rest,
-    title: trimTitle(title),
+    title: trimTitle(key),
+    color: getColorHEX(color),
     region,
     aws_account_id: match?.groups?.aws_account_id ?? aws_account_id,
     role_name: match?.groups?.role_name ?? role_name,
-  };
+  });
 };
 
 export function mapConfig(config: StoredConfig): AWSConfig {
   const entries = Object.keys(config)
-    .filter((val) => isValidConfigEntry(config[val]))
-    .map((configEntry) => buildConfigItem(configEntry, config[configEntry]))
-    .filter(isValidConfigItem)
-    .map(mapColor) as AWSConfig;
+    .map(buildConfigItem(config))
+    .filter(isValidConfigItem) as AWSConfig;
 
   return entries
     .sort(sortByGroupIndex(entries));

--- a/src/common/config/mapper.ts
+++ b/src/common/config/mapper.ts
@@ -7,8 +7,8 @@ import { removeUndefinedEntries } from '../util';
 const ROLE_ARN_REGEX = /^arn:aws:iam::(?<aws_account_id>\d{12}):role\/(?<role_name>[\w+=,.@-]+)/;
 const HEX_COLOR_REGEX = /^(?<hex>[0-9A-Fa-f]{3,8})$/;
 
-const isValidConfigItem = ({ aws_account_id }: Partial<AWSConfigItem>): boolean =>
- !!aws_account_id;
+const isValidConfigItem = ({ aws_account_id, role_name }: Partial<AWSConfigItem>): boolean =>
+ !!aws_account_id && !!role_name;
 
 function getColorHEX(color: string) {
   const match = new RegExp(HEX_COLOR_REGEX).exec(color);
@@ -59,6 +59,7 @@ const buildConfigItem = (config: StoredConfig) => (key: string): Partial<AWSConf
   const { role_arn = '', aws_account_id, role_name, region: regionTo, color = '', ...rest } = config[key];  
   const region = availableRegions.includes(regionTo || '') ? regionTo : undefined;
   const match = new RegExp(ROLE_ARN_REGEX).exec(role_arn);
+  const source = config[rest.source_profile ?? ''] ?? {};
 
   return removeUndefinedEntries({
     ...rest,
@@ -66,7 +67,7 @@ const buildConfigItem = (config: StoredConfig) => (key: string): Partial<AWSConf
     color: getColorHEX(color),
     region,
     aws_account_id: match?.groups?.aws_account_id ?? aws_account_id,
-    role_name: match?.groups?.role_name ?? role_name,
+    role_name: match?.groups?.role_name ?? role_name ?? source.target_role_name,
   });
 };
 

--- a/src/common/util/index.ts
+++ b/src/common/util/index.ts
@@ -1,1 +1,2 @@
 export { groupBy } from './groupBy';
+export { removeUndefinedEntries } from './removeUndefinedEntries';

--- a/src/common/util/removeUndefinedEntries.ts
+++ b/src/common/util/removeUndefinedEntries.ts
@@ -1,0 +1,2 @@
+export const removeUndefinedEntries = (obj: object) => Object.fromEntries(
+  Object.entries(obj).filter(([_, v]) => v));

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,7 @@ type AWSConfigOptionalData = {
 type AWSConfigItem = {
   title: string,
   aws_account_id: string,
-  role_name?: string,
+  role_name: string,
   selected?: boolean,
 } & AWSConfigOptionalData
 
@@ -29,6 +29,7 @@ type AWSStoredConfigItem = {
   role_name?: string,
   role_arn?: string,
   source_profile?: string,
+  target_role_name?: string,
 } & AWSConfigOptionalData
 
 type StoredConfig = Record<string, AWSStoredConfigItem>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,8 +17,7 @@ type AWSConfigOptionalData = {
 type AWSConfigItem = {
   title: string,
   aws_account_id: string,
-  role_name: string,
-
+  role_name?: string,
   selected?: boolean,
 } & AWSConfigOptionalData
 
@@ -28,7 +27,8 @@ type AWSConfigItemState = AWSConfigItem & { selected: boolean }
 type AWSStoredConfigItem = {
   aws_account_id?: string,
   role_name?: string,
-  role_arn?: string
+  role_arn?: string,
+  source_profile?: string,
 } & AWSConfigOptionalData
 
 type StoredConfig = Record<string, AWSStoredConfigItem>
@@ -36,7 +36,7 @@ type StoredConfig = Record<string, AWSStoredConfigItem>
 type SwitchRoleFormFromExtension = { _fromAWSRoleSwitchExtension?: 'true' }
 type SwitchRoleForm = {
   account: string,
-  roleName: string,
+  roleName?: string,
   region?: string,
   color?: string,
   displayName?: string,


### PR DESCRIPTION
Makes aws-role-switch compatible with https://github.com/tilfinltd/aws-extend-switch-roles

closes #225