### PR TITLE
Fix role_arn for IAM role with path not being picked up correctly from config

### DIFF
--- a/src/common/config/mapper.spec.ts
+++ b/src/common/config/mapper.spec.ts
@@ -358,6 +358,7 @@ describe('role_arn handling', () => {
     ['arn:aws:iam::123456789111:role/user,role,foo', 'user,role,foo'],
     ['arn:aws:iam::123456789111:role/user@role-foo', 'user@role-foo'],
     ['arn:aws:iam::123456789111:role/userRole+11', 'userRole+11'],
+    ['arn:aws:iam::123456789111:role/with/path', 'with/path'],
   ])('test role_arn %s', (arn, role_name) => {
     const config = mapConfig({ foo: { role_arn: arn } });
     expect(config[0].aws_account_id).toBe('123456789111');

--- a/src/common/config/mapper.ts
+++ b/src/common/config/mapper.ts
@@ -4,7 +4,7 @@ import { availableRegions } from './availableRegions';
 import { removeUndefinedEntries } from '../util';
 
 // Possible role_name syntax: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
-const ROLE_ARN_REGEX = /^arn:aws:iam::(?<aws_account_id>\d{12}):role\/(?<role_name>[\w+=,.@-]+)/;
+const ROLE_ARN_REGEX = /^arn:aws:iam::(?<aws_account_id>\d{12}):role\/(?<role_name>[\w+=,.@\\/-]+)/;
 const HEX_COLOR_REGEX = /^(?<hex>[0-9A-Fa-f]{3,8})$/;
 
 const isValidConfigItem = ({ aws_account_id, role_name, target_role_name }: Partial<AWSConfigItem>): boolean =>


### PR DESCRIPTION
Slashes are used to denote paths in IAM roles: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names

This fixes role_arn's with slashes not being picked up correctly from the config. When using the extension without the fix with a role which includes paths, the result is being redirected to the Switch Role screen with an error. Instead of the full role path (e.g. `foo/bar`) only the first part of the path of the role's path is being used (e.g. `foo`):

![](https://github.com/janstuemmel/aws-role-switch/assets/616991/db1b108d-f41c-40b1-bd78-90b49d21bb71)

![](https://github.com/janstuemmel/aws-role-switch/assets/616991/51dc9a8e-f71f-4b21-bcf0-a6bf1b8c02d2)

Could also result in the wrong role being used should a role with that name happen to exist.

Before:

![](https://github.com/janstuemmel/aws-role-switch/assets/616991/28fecce3-8cf9-471b-9ab9-cb31f6fd49df)

After:

![](https://github.com/janstuemmel/aws-role-switch/assets/616991/e813d64e-8460-4b20-8a55-4c8391e7ef44)