### PR TITLE
feature: Add account ID copy functionality

### DIFF
--- a/src/popup/components/Popup.tsx
+++ b/src/popup/components/Popup.tsx
@@ -13,6 +13,7 @@ import SectionList from './SectionList';
 type PopupProps = {
   roles: AWSConfigItem[];
   executeSwitch?: (item: AWSConfigItem) => void;
+  onCopyAccountId?: (accountId: string) => void;
   headerRight?: JSX.Element | null;
 };
 
@@ -30,6 +31,7 @@ const EmptyList = ({emptyConfig}: {emptyConfig: boolean}) => (
 export const Popup = ({
   roles,
   executeSwitch = () => {},
+  onCopyAccountId = () => {},
   headerRight = null,
 }: PopupProps) => {
   const [filter, setFiler] = useState('');
@@ -58,6 +60,7 @@ export const Popup = ({
               {...props}
               {...item}
               onClick={() => executeSwitch(item)}
+              onCopyAccountId={() => onCopyAccountId(item.aws_account_id)}
             />
           )}
           renderSection={({title, ...props}) => (

--- a/src/popup/components/RoleItem.tsx
+++ b/src/popup/components/RoleItem.tsx
@@ -1,16 +1,68 @@
-import {Icon, MenuItem, type MenuItemProps} from '@blueprintjs/core';
-import React from 'react';
+import {Button, Icon, MenuItem, type MenuItemProps} from '@blueprintjs/core';
+import React, {useEffect, useState} from 'react';
 
 export const RoleItem = ({
   title,
   aws_account_id,
   color,
+  onClick,
+  onCopyAccountId,
+  selected,
   ...props
-}: AWSConfigItem & Partial<MenuItemProps>) => (
-  <MenuItem
-    {...props}
-    icon={<Icon icon="full-circle" color={color} />}
-    text={title}
-    label={aws_account_id}
-  />
-);
+}: AWSConfigItem &
+  Partial<MenuItemProps> & {
+    onCopyAccountId?: () => void;
+    selected?: boolean;
+  }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onCopyAccountId?.();
+  };
+
+  useEffect(() => {
+    if (!isHovered) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+
+      // Mac: Cmd+C, Windows/Linux: Ctrl+Shift+C
+      const shouldCopy = isMac
+        ? e.metaKey && e.key === 'c' && !e.ctrlKey && !e.shiftKey
+        : e.ctrlKey && e.shiftKey && e.key === 'c' && !e.metaKey;
+
+      if (shouldCopy) {
+        e.preventDefault();
+        onCopyAccountId?.();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isHovered, onCopyAccountId]);
+
+  return (
+    <MenuItem
+      {...props}
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      icon={<Icon icon="full-circle" color={color} />}
+      text={title}
+      labelElement={
+        <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+          <span>{aws_account_id}</span>
+          {isHovered && (
+            <Button
+              icon="duplicate"
+              minimal
+              small
+              onClick={handleCopy}
+            />
+          )}
+        </div>
+      }
+    />
+  );
+};

--- a/src/popup/components/SectionList.tsx
+++ b/src/popup/components/SectionList.tsx
@@ -49,7 +49,7 @@ export default <T,>({
       data.map((gn) =>
         rows.findIndex((n) => n.type === 'section' && n.title === gn.title),
       ),
-    [],
+    [data, rows],
   );
   const isSticky = (index: number) => stickyIndexes.includes(index);
   const isActiveSticky = (index: number) =>

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -44,11 +44,22 @@ const App = () => {
     });
   }, []);
 
+  const handleCopyAccountId = (accountId: string) => {
+    navigator.clipboard.writeText(accountId);
+    Notification.show({
+      message: `Copied ${accountId}`,
+      intent: 'success',
+      timeout: 2000,
+      icon: 'tick',
+    });
+  };
+
   return (
     <div className={`bp5-${theme}`}>
       <Popup
         executeSwitch={executeSwitch}
         roles={roles}
+        onCopyAccountId={handleCopyAccountId}
         headerRight={
           <>
             <Button


### PR DESCRIPTION
## Summary
- Adds a copy button to each role item that appears on hover
- Supports keyboard shortcuts for copying account IDs:
  - Mac: Cmd+C
  - Windows/Linux: Ctrl+Shift+C
- Displays a toast notification when the account ID is copied
